### PR TITLE
Make event formatter public

### DIFF
--- a/src/event_formatter.rs
+++ b/src/event_formatter.rs
@@ -17,6 +17,7 @@ use tracing_subscriber::{
     registry::LookupSpan,
 };
 
+/// Error type for event formatting
 #[derive(Debug, thiserror::Error)]
 enum Error {
     #[error(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
 #![allow(clippy::needless_doctest_main)]
 #![doc = include_str!("../README.md")]
 
-mod event_formatter;
+/// Event formatter for Stackdriver
+pub mod event_formatter;
 mod google;
 mod layer;
 mod serializers;


### PR DESCRIPTION
change event_formatter into public to use as a event formatter of tracing-subscriber